### PR TITLE
chore: remove auto run of ios deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -163,7 +163,6 @@ jobs:
     # does not block the overall workflow or branch protection rules.
     continue-on-error: true
     if: >
-      github.event_name == 'push' ||
       inputs.platform == 'ios' ||
       inputs.platform == 'all'
     runs-on: ubuntu-latest # EAS Build runs in Expo's cloud; no macOS runner needed.


### PR DESCRIPTION
currently the developer account for ios is missing. Removing the step from auto run when new releases are created.