### PR TITLE
feat: Temporal tracking of dice in video frames enhancement

### DIFF
--- a/__mocks__/fileMock.js
+++ b/__mocks__/fileMock.js
@@ -1,0 +1,1 @@
+module.exports = 'test-file-stub';

--- a/jest.config.js
+++ b/jest.config.js
@@ -3,5 +3,8 @@ module.exports = {
   transformIgnorePatterns: [
     'node_modules/(?!((jest-)?react-native|@react-native(-community)?)|expo(nent)?|@expo(nent)?/.*|@expo-google-fonts/.*|react-navigation|@react-navigation/.*|@sentry/react-native|native-base|react-native-svg|nativewind|react-native-reanimated|react-native-vision-camera|react-native-fast-tflite)',
   ],
+  moduleNameMapper: {
+    '\\.tflite$': '<rootDir>/__mocks__/fileMock.js',
+  },
   setupFilesAfterEnv: ['<rootDir>/jest-setup.js'],
 };

--- a/src/components/__tests__/dice-scanner.test.tsx
+++ b/src/components/__tests__/dice-scanner.test.tsx
@@ -1,0 +1,109 @@
+import React from 'react';
+import { render, screen, userEvent } from '@testing-library/react-native';
+import { useTensorflowModel } from 'react-native-fast-tflite';
+import { useCameraPermissions } from '../../hooks/use-camera-permissions';
+import { DiceScanner } from '../dice-scanner';
+
+// Mock the native modules and hooks
+jest.mock('react-native-vision-camera', () => ({
+  Camera: () => null,
+  useCameraDevice: () => ({ id: 'back-camera' }),
+  useFrameProcessor: () => jest.fn(),
+  runAtTargetFps: jest.fn(),
+}));
+
+jest.mock('react-native-worklets-core', () => ({
+  Worklets: {
+    createRunOnJS: (fn: any) => fn,
+    createSharedValue: (val: any) => ({ value: val }),
+  },
+}));
+
+jest.mock('vision-camera-resize-plugin', () => ({
+  useResizePlugin: () => ({ resize: jest.fn() }),
+}));
+
+jest.mock('react-native-fast-tflite', () => ({
+  useTensorflowModel: jest.fn(),
+}));
+
+jest.mock('../../hooks/use-camera-permissions', () => ({
+  useCameraPermissions: jest.fn(),
+}));
+
+describe('DiceScanner', () => {
+  const mockOnScanComplete = jest.fn();
+  const mockOnClose = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (useCameraPermissions as jest.Mock).mockReturnValue({
+      hasPermission: true,
+      permissionError: false,
+    });
+    (useTensorflowModel as jest.Mock).mockReturnValue({
+      state: 'loaded',
+      model: {
+        inputs: [{ shape: [1, 640, 640, 3] }],
+        outputs: [{ shape: [1, 8400, 11] }],
+        runSync: jest.fn(),
+      },
+    });
+  });
+
+  it('renders correctly when permissions are granted', () => {
+    render(
+      <DiceScanner
+        neededCount={5}
+        onScanComplete={mockOnScanComplete}
+        onClose={mockOnClose}
+      />,
+    );
+    // The CloseButton has accessibilityRole="button" and accessibilityLabel="Close"
+    expect(screen.getByRole('button', { name: 'Close' })).toBeTruthy();
+  });
+
+  it('calls onClose when close button is pressed', async () => {
+    const user = userEvent.setup();
+    render(
+      <DiceScanner
+        neededCount={5}
+        onScanComplete={mockOnScanComplete}
+        onClose={mockOnClose}
+      />,
+    );
+
+    await user.press(screen.getByRole('button', { name: 'Close' }));
+    expect(mockOnClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('shows permission error when denied', () => {
+    (useCameraPermissions as jest.Mock).mockReturnValue({
+      hasPermission: false,
+      permissionError: true,
+    });
+    render(
+      <DiceScanner
+        neededCount={5}
+        onScanComplete={mockOnScanComplete}
+        onClose={mockOnClose}
+      />,
+    );
+    expect(screen.getByText('Camera permission denied.')).toBeTruthy();
+  });
+
+  it('shows loading state when camera is null but no error', () => {
+    (useCameraPermissions as jest.Mock).mockReturnValue({
+      hasPermission: false,
+      permissionError: false,
+    });
+    render(
+      <DiceScanner
+        neededCount={5}
+        onScanComplete={mockOnScanComplete}
+        onClose={mockOnClose}
+      />,
+    );
+    expect(screen.getByText('Loading camera...')).toBeTruthy();
+  });
+});

--- a/src/components/__tests__/dice-scanner.test.tsx
+++ b/src/components/__tests__/dice-scanner.test.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { render, screen, userEvent } from '@testing-library/react-native';
 import { useTensorflowModel } from 'react-native-fast-tflite';
 import { useCameraPermissions } from '../../hooks/use-camera-permissions';
+import type { TrackerState } from '../../lib/dice-tracker';
 import { DiceScanner } from '../dice-scanner';
 
 // Mock the native modules and hooks
@@ -14,8 +15,12 @@ jest.mock('react-native-vision-camera', () => ({
 
 jest.mock('react-native-worklets-core', () => ({
   Worklets: {
-    createRunOnJS: (fn: any) => fn,
-    createSharedValue: (val: any) => ({ value: val }),
+    createRunOnJS: <TArgs extends unknown[], TResult>(
+      fn: (...args: TArgs) => TResult,
+    ) => fn,
+    createSharedValue: (val: TrackerState) => ({
+      value: val,
+    }),
   },
 }));
 

--- a/src/components/ar-overlay.tsx
+++ b/src/components/ar-overlay.tsx
@@ -2,10 +2,9 @@ import React, { useEffect } from 'react';
 import { Text, View } from 'react-native';
 import type { DiceDetection } from '../domain/dice-detection';
 import { CONFIDENCE_THRESHOLD } from '../lib/dice-processor';
+import { IS_PRE_RELEASE } from '../lib/app-info';
 
-const packageJson = require('../../package.json');
-const isDebugBuild =
-  __DEV__ || (packageJson as { version: string }).version.includes('-dev');
+const isDebugBuild = __DEV__ || IS_PRE_RELEASE;
 
 interface AROverlayProps {
   detections: DiceDetection[];

--- a/src/components/ar-overlay.tsx
+++ b/src/components/ar-overlay.tsx
@@ -3,6 +3,9 @@ import { Text, View } from 'react-native';
 import type { DiceDetection } from '../domain/dice-detection';
 import { CONFIDENCE_THRESHOLD } from '../lib/dice-processor';
 
+const packageJson = require('../../package.json');
+const isDebugBuild = __DEV__ || packageJson.version.includes('-dev');
+
 interface AROverlayProps {
   detections: DiceDetection[];
   targetCount: number;
@@ -67,6 +70,13 @@ export const AROverlay = ({
             }}
           >
             <Text className="text-xs font-bold text-white">{det.value}</Text>
+            {isDebugBuild && det.id && (
+              <View className="absolute -bottom-5 -right-2 rounded bg-black/60 px-1 py-0.5">
+                <Text className="text-[10px] text-white">
+                  #{det.id.replace('die-', '')} [{det.historyLength}/10]
+                </Text>
+              </View>
+            )}
           </View>
         );
       })}

--- a/src/components/ar-overlay.tsx
+++ b/src/components/ar-overlay.tsx
@@ -4,7 +4,8 @@ import type { DiceDetection } from '../domain/dice-detection';
 import { CONFIDENCE_THRESHOLD } from '../lib/dice-processor';
 
 const packageJson = require('../../package.json');
-const isDebugBuild = __DEV__ || packageJson.version.includes('-dev');
+const isDebugBuild =
+  __DEV__ || (packageJson as { version: string }).version.includes('-dev');
 
 interface AROverlayProps {
   detections: DiceDetection[];

--- a/src/components/ar-overlay.tsx
+++ b/src/components/ar-overlay.tsx
@@ -58,8 +58,8 @@ export const AROverlay = ({
 
         return (
           <View
-            key={index}
-            testID={`detection-box-${index}`}
+            key={det.id ?? index}
+            testID={`detection-box-${det.id ?? index}`}
             className="absolute items-center justify-center border-2"
             style={{
               left: det.x,

--- a/src/components/dice-scanner.tsx
+++ b/src/components/dice-scanner.tsx
@@ -65,7 +65,14 @@ export const DiceScanner = ({
     height: number;
   } | null>(null);
 
-  const trackerState = Worklets.createSharedValue(createInitialTrackerState());
+  // Initialize the tracker state once and persist it across renders
+  const trackerStateRef = React.useRef<any>(null);
+  if (trackerStateRef.current === null) {
+    trackerStateRef.current = Worklets.createSharedValue(
+      createInitialTrackerState(),
+    );
+  }
+  const trackerState = trackerStateRef.current;
 
   const frameProcessor = useFrameProcessor(
     (frame) => {

--- a/src/components/dice-scanner.tsx
+++ b/src/components/dice-scanner.tsx
@@ -20,6 +20,10 @@ import {
   CONFIDENCE_THRESHOLD,
   processDiceFrame,
 } from '../lib/dice-processor';
+import {
+  createInitialTrackerState,
+  updateDiceTracks,
+} from '../lib/dice-tracker';
 
 interface DiceScannerProps {
   neededCount: number;
@@ -61,6 +65,8 @@ export const DiceScanner = ({
     height: number;
   } | null>(null);
 
+  const trackerState = Worklets.createSharedValue(createInitialTrackerState());
+
   const frameProcessor = useFrameProcessor(
     (frame) => {
       'worklet';
@@ -100,7 +106,7 @@ export const DiceScanner = ({
           const outputTensor = outputs[0] as Float32Array;
           const outputShape = tfliteModel.outputs[0].shape;
 
-          const finalDetections = processDiceFrame({
+          const rawDetections = processDiceFrame({
             outputTensor,
             outputShape,
             cropY: mapping.screenCropY,
@@ -109,11 +115,17 @@ export const DiceScanner = ({
             confidenceThreshold: CONFIDENCE_THRESHOLD,
           });
 
-          setDetectionsJS(finalDetections);
+          const { state: newState, stabilizedDetections } = updateDiceTracks(
+            trackerState.value,
+            rawDetections,
+          );
+          trackerState.value = newState;
 
-          if (finalDetections.length >= neededCount) {
+          setDetectionsJS(stabilizedDetections);
+
+          if (stabilizedDetections.length >= neededCount) {
             setFinalValuesJS(
-              finalDetections.slice(0, neededCount).map((d) => d.value),
+              stabilizedDetections.slice(0, neededCount).map((d) => d.value),
             );
           }
         } catch (error: any) {

--- a/src/components/dice-scanner.tsx
+++ b/src/components/dice-scanner.tsx
@@ -67,14 +67,10 @@ export const DiceScanner = ({
     height: number;
   } | null>(null);
 
-  // Initialize the tracker state once and persist it across renders
-  const trackerStateRef = React.useRef<ISharedValue<TrackerState> | null>(null);
-  if (trackerStateRef.current === null) {
-    trackerStateRef.current = Worklets.createSharedValue(
-      createInitialTrackerState(),
-    );
-  }
-  const trackerState = trackerStateRef.current;
+  // Initialize the tracker state once per mount and persist it across renders
+  const [trackerState] = React.useState<ISharedValue<TrackerState>>(() =>
+    Worklets.createSharedValue(createInitialTrackerState()),
+  );
 
   const frameProcessor = useFrameProcessor(
     (frame) => {

--- a/src/components/dice-scanner.tsx
+++ b/src/components/dice-scanner.tsx
@@ -8,6 +8,7 @@ import {
   useFrameProcessor,
 } from 'react-native-vision-camera';
 import { Worklets } from 'react-native-worklets-core';
+import type { ISharedValue } from 'react-native-worklets-core';
 import { useResizePlugin } from 'vision-camera-resize-plugin';
 import { AROverlay } from './ar-overlay';
 import { CaptureButton } from './capture-button';
@@ -24,6 +25,7 @@ import {
   createInitialTrackerState,
   updateDiceTracks,
 } from '../lib/dice-tracker';
+import type { TrackerState } from '../lib/dice-tracker';
 
 interface DiceScannerProps {
   neededCount: number;
@@ -66,7 +68,7 @@ export const DiceScanner = ({
   } | null>(null);
 
   // Initialize the tracker state once and persist it across renders
-  const trackerStateRef = React.useRef<any>(null);
+  const trackerStateRef = React.useRef<ISharedValue<TrackerState> | null>(null);
   if (trackerStateRef.current === null) {
     trackerStateRef.current = Worklets.createSharedValue(
       createInitialTrackerState(),
@@ -128,11 +130,26 @@ export const DiceScanner = ({
           );
           trackerState.value = newState;
 
-          setDetectionsJS(stabilizedDetections);
+          // Sort detections by priority:
+          // 1. Manual overrides first
+          // 2. Most stable (highest historyLength) second
+          // 3. Highest confidence as tie-breaker
+          const sortedDetections = [...stabilizedDetections].sort((a, b) => {
+            if (a.overrideValue && !b.overrideValue) return -1;
+            if (!a.overrideValue && b.overrideValue) return 1;
 
-          if (stabilizedDetections.length >= neededCount) {
+            if ((b.historyLength || 0) !== (a.historyLength || 0)) {
+              return (b.historyLength || 0) - (a.historyLength || 0);
+            }
+
+            return b.confidence - a.confidence;
+          });
+
+          setDetectionsJS(sortedDetections);
+
+          if (sortedDetections.length >= neededCount) {
             setFinalValuesJS(
-              stabilizedDetections.slice(0, neededCount).map((d) => d.value),
+              sortedDetections.slice(0, neededCount).map((d) => d.value),
             );
           }
         } catch (error: any) {

--- a/src/domain/dice-detection.ts
+++ b/src/domain/dice-detection.ts
@@ -1,7 +1,9 @@
 import type { DieValue } from './die-value';
 
 export interface DiceDetection {
+  id?: string;
   value: DieValue;
+  overrideValue?: DieValue;
   x: number;
   y: number;
   width: number;

--- a/src/domain/dice-detection.ts
+++ b/src/domain/dice-detection.ts
@@ -2,6 +2,7 @@ import type { DieValue } from './die-value';
 
 export interface DiceDetection {
   id?: string;
+  historyLength?: number;
   value: DieValue;
   overrideValue?: DieValue;
   x: number;

--- a/src/lib/AI_INSTRUCTIONS.md
+++ b/src/lib/AI_INSTRUCTIONS.md
@@ -58,6 +58,25 @@ Parses the raw YOLOv8 TFLite output tensor into a list of detected dice.
 
 **Coordinate denormalisation:** normalised coords are multiplied by `cropSize` (the on-screen pixel size of the square crop) and offset by `cropY` / `offsetX` to get absolute screen positions.
 
-**NMS:** detections are sorted by confidence descending, then any box whose top-left corner (`x`/`y`) is within 30px (in both axes) of an already-accepted box's top-left corner is dropped as a duplicate. Note: comparing top-left corners is a known approximation — comparing centres would be more geometrically correct for NMS (two boxes of different sizes with the same centre would compare differently) but the current approach works well enough in practice.
+**NMS:** detections are sorted by confidence descending, then any box whose centre is within 30px (in both axes) of an already-accepted box's centre is dropped as a duplicate.
 
 **`confidenceThreshold`** is set by the caller (currently `0.15` in `DiceScanner`). Tune it there, not here.
+
+---
+
+## dice-tracker.ts
+
+Stateful tracking of dice identities across multiple frames to enable stabilization and smoothing. Functions are marked `'worklet'` and run on the worklet thread.
+
+### `updateDiceTracks(state: TrackerState, currentDetections: DiceDetection[])`
+
+The core tracking loop. Links raw detections from `processDiceFrame` to persistent IDs.
+
+1.  **Constellation Matching:** Predicts global camera movement (pan) by finding the translation vector that aligns the most existing tracks with new detections. This prevents "ghosting" during fast movement.
+2.  **Global Matching:** Uses a distance matrix to match tracks to new detections based on the closest pairs globally. This prevents "ID stealing" where a missing die's ID is greedily taken by a neighbor.
+3.  **History & Voting:** Each die maintains a stack of the last 10 frames. The reported `value` is the **mode** (most frequent) of this history, filtering out ML flickering.
+4.  **Revival Logic:** Dice that are missing for up to 5 frames are kept in internal memory (but not rendered). If they reappear, they reconnect to their original ID and history. Mark "missing" frames as `isPhantom: true` so they don't skew the voting history.
+5.  **Manual Overrides:** If a detection has an `overrideValue`, it is respected immediately, bypassing the voting logic.
+
+Returns a new `TrackerState` (to be stored in a `SharedValue`) and a list of `stabilizedDetections` (only containing dice physically present in the current frame).
+

--- a/src/lib/AI_INSTRUCTIONS.md
+++ b/src/lib/AI_INSTRUCTIONS.md
@@ -75,8 +75,7 @@ The core tracking loop. Links raw detections from `processDiceFrame` to persiste
 1.  **Constellation Matching:** Predicts global camera movement (pan) by finding the translation vector that aligns the most existing tracks with new detections. This prevents "ghosting" during fast movement.
 2.  **Global Matching:** Uses a distance matrix to match tracks to new detections based on the closest pairs globally. This prevents "ID stealing" where a missing die's ID is greedily taken by a neighbor.
 3.  **History & Voting:** Each die maintains a stack of the last 10 frames. The reported `value` is the **mode** (most frequent) of this history, filtering out ML flickering.
-4.  **Revival Logic:** Dice that are missing for up to 5 frames are kept in internal memory (but not rendered). If they reappear, they reconnect to their original ID and history. Mark "missing" frames as `isPhantom: true` so they don't skew the voting history.
+4.  **Revival Logic:** Dice that are missing for up to 5 frames are kept in internal memory (but not rendered). If they reappear, they reconnect to their original ID and history. While a die is missing, no phantom history entry is appended; its existing history is left unchanged.
 5.  **Manual Overrides:** If a detection has an `overrideValue`, it is respected immediately, bypassing the voting logic.
 
 Returns a new `TrackerState` (to be stored in a `SharedValue`) and a list of `stabilizedDetections` (only containing dice physically present in the current frame).
-

--- a/src/lib/__tests__/dice-processor.test.ts
+++ b/src/lib/__tests__/dice-processor.test.ts
@@ -47,6 +47,77 @@ describe('dice-processor', () => {
     // x = 540 - 54 = 486
     expect(results[0].x).toBeCloseTo(486, 0);
   });
+
+  it('should parse an 11-feature YOLOv8 tensor in standard format (non-transposed: [1, 8400, 11])', () => {
+    const numAnchors = 8400;
+    const numFeatures = 11;
+    const tensor = new Float32Array(numFeatures * numAnchors);
+
+    // Anchor at index 100: [cx, cy, w, h, c1...c6, padding]
+    const off = 100 * numFeatures;
+    tensor[off + 0] = 0.2; // cx
+    tensor[off + 1] = 0.3; // cy
+    tensor[off + 2] = 0.05; // w
+    tensor[off + 3] = 0.05; // h
+    tensor[off + 4 + 2] = 0.8; // Class 3 (index 2)
+
+    const results = processDiceFrame({
+      outputTensor: tensor,
+      outputShape: [1, 8400, 11],
+      cropY: 0,
+      cropSize: 1000,
+      confidenceThreshold: 0.5,
+    });
+
+    expect(results).toHaveLength(1);
+    expect(results[0].value).toBe(3);
+    expect(results[0].confidence).toBeCloseTo(0.8);
+    // x = (0.2 * 1000) - (0.05 * 1000 / 2) = 200 - 25 = 175
+    expect(results[0].x).toBeCloseTo(175, 1);
+  });
+
+  it('should apply Non-Maximum Suppression (NMS) to remove duplicates', () => {
+    const numAnchors = 8400;
+    const numFeatures = 11;
+    const tensor = new Float32Array(numFeatures * numAnchors);
+
+    // Anchor 0: A high-confidence detection
+    tensor[0 * numAnchors + 0] = 0.5;
+    tensor[1 * numAnchors + 0] = 0.5;
+    tensor[2 * numAnchors + 0] = 0.1;
+    tensor[3 * numAnchors + 0] = 0.1;
+    tensor[9 * numAnchors + 0] = 0.9; // Value 6
+
+    // Anchor 1: A lower-confidence detection at almost the same spot
+    tensor[0 * numAnchors + 1] = 0.501;
+    tensor[1 * numAnchors + 1] = 0.501;
+    tensor[2 * numAnchors + 1] = 0.1;
+    tensor[3 * numAnchors + 1] = 0.1;
+    tensor[9 * numAnchors + 1] = 0.8; // Value 6
+
+    // Anchor 2: A detection far away (should not be suppressed)
+    tensor[0 * numAnchors + 2] = 0.1;
+    tensor[1 * numAnchors + 2] = 0.1;
+    tensor[2 * numAnchors + 2] = 0.1;
+    tensor[3 * numAnchors + 2] = 0.1;
+    tensor[4 * numAnchors + 2] = 0.7; // Value 1
+
+    const results = processDiceFrame({
+      outputTensor: tensor,
+      outputShape: [1, 11, 8400],
+      cropY: 0,
+      cropSize: 1000,
+      confidenceThreshold: 0.5,
+    });
+
+    // Should have 2 detections, not 3 (one was suppressed)
+    expect(results).toHaveLength(2);
+    expect(results.map((r) => r.value)).toContain(6);
+    expect(results.map((r) => r.value)).toContain(1);
+    // The high confidence 6 should be the one that remained
+    const die6 = results.find((r) => r.value === 6);
+    expect(die6?.confidence).toBeCloseTo(0.9);
+  });
 });
 
 describe('calculateCoordinateMapping', () => {

--- a/src/lib/__tests__/dice-tracker.test.ts
+++ b/src/lib/__tests__/dice-tracker.test.ts
@@ -1,0 +1,119 @@
+import type { DiceDetection } from '../../domain/dice-detection';
+import { createInitialTrackerState, updateDiceTracks } from '../dice-tracker';
+
+describe('dice-tracker', () => {
+  const mockDetection = (
+    x: number,
+    y: number,
+    value: number = 1,
+  ): DiceDetection => ({
+    x,
+    y,
+    width: 50,
+    height: 50,
+    value: value as any,
+    confidence: 0.9,
+  });
+
+  it('assigns unique IDs to new detections', () => {
+    const state = createInitialTrackerState();
+    const { state: nextState, stabilizedDetections } = updateDiceTracks(state, [
+      mockDetection(10, 10),
+      mockDetection(100, 100),
+    ]);
+
+    expect(stabilizedDetections).toHaveLength(2);
+    expect(stabilizedDetections[0].id).toBe('die-1');
+    expect(stabilizedDetections[1].id).toBe('die-2');
+    expect(nextState.nextId).toBe(3);
+  });
+
+  it('keeps the same ID for a die that moves slightly', () => {
+    const state = createInitialTrackerState();
+    // Frame 1
+    const { state: state1, stabilizedDetections: det1 } = updateDiceTracks(
+      state,
+      [mockDetection(10, 10)],
+    );
+    expect(det1[0].id).toBe('die-1');
+
+    // Frame 2: Moved 20px
+    const { stabilizedDetections: det2 } = updateDiceTracks(state1, [
+      mockDetection(30, 30),
+    ]);
+    expect(det2[0].id).toBe('die-1');
+    expect(det2[0].x).toBe(30);
+  });
+
+  it('stabilizes the value using history (voting)', () => {
+    let state = createInitialTrackerState();
+
+    // 3 frames of value 6
+    for (let i = 0; i < 3; i++) {
+      const res = updateDiceTracks(state, [mockDetection(10, 10, 6)]);
+      state = res.state;
+    }
+
+    // 1 frame of value 1 (a glitch)
+    const { stabilizedDetections } = updateDiceTracks(state, [
+      mockDetection(10, 10, 1),
+    ]);
+
+    // Should still report 6 because it's the most frequent in history
+    expect(stabilizedDetections[0].value).toBe(6);
+  });
+
+  it('recovers a die and its ID after a flicker (missing frames)', () => {
+    let state = createInitialTrackerState();
+
+    // Frame 1: Detection exists
+    const res1 = updateDiceTracks(state, [mockDetection(10, 10)]);
+    state = res1.state;
+    expect(res1.stabilizedDetections).toHaveLength(1);
+    const originalId = res1.stabilizedDetections[0].id;
+
+    // Frame 2: Detection is missing
+    const res2 = updateDiceTracks(state, []);
+    state = res2.state;
+    expect(res2.stabilizedDetections).toHaveLength(0); // Should not draw ghost
+
+    // Frame 3: Detection returns
+    const res3 = updateDiceTracks(state, [mockDetection(12, 12)]);
+    expect(res3.stabilizedDetections).toHaveLength(1);
+    expect(res3.stabilizedDetections[0].id).toBe(originalId);
+  });
+
+  it('compensates for global camera movement (constellation matching)', () => {
+    let state = createInitialTrackerState();
+
+    // Two dice at 10,10 and 50,10
+    const res1 = updateDiceTracks(state, [
+      mockDetection(10, 10),
+      mockDetection(50, 10),
+    ]);
+    state = res1.state;
+
+    // Huge camera pan: dice are now at 510, 510 and 550, 510
+    // This is a 500px jump, far beyond the 80px threshold!
+    const res2 = updateDiceTracks(state, [
+      mockDetection(510, 510),
+      mockDetection(550, 510),
+    ]);
+
+    // Should successfully match IDs because it detected the constellation shift
+    expect(res2.stabilizedDetections).toHaveLength(2);
+    expect(res2.stabilizedDetections.map((d) => d.id)).toContain('die-1');
+    expect(res2.stabilizedDetections.map((d) => d.id)).toContain('die-2');
+  });
+
+  it('respects manual overrides immediately', () => {
+    const state = createInitialTrackerState();
+
+    const detection = mockDetection(10, 10, 6);
+    detection.overrideValue = 1 as any;
+
+    const { stabilizedDetections } = updateDiceTracks(state, [detection]);
+
+    expect(stabilizedDetections[0].value).toBe(1);
+  });
+});

--- a/src/lib/__tests__/dice-tracker.test.ts
+++ b/src/lib/__tests__/dice-tracker.test.ts
@@ -107,6 +107,39 @@ describe('dice-tracker', () => {
     expect(res2.stabilizedDetections.map((d) => d.id)).toContain('die-2');
   });
 
+  it('prevents greedy ID swapping when a nearby die is removed', () => {
+    let state = createInitialTrackerState();
+
+    // Frame 1: Three dice close to each other
+    // Track 1 is at x=100. Track 2 is at x=150. Track 3 is at x=200.
+    const res1 = updateDiceTracks(state, [
+      mockDetection(100, 100), // die-1
+      mockDetection(150, 100), // die-2
+      mockDetection(200, 100), // die-3
+    ]);
+    state = res1.state;
+
+    // Frame 2: The first die (die-1 at x=100) is removed.
+    // If the algorithm is greedy, Track 1 might steal the detection at x=150
+    // before Track 2 gets a chance to claim it.
+    const res2 = updateDiceTracks(state, [
+      mockDetection(150, 100),
+      mockDetection(200, 100),
+    ]);
+
+    expect(res2.stabilizedDetections).toHaveLength(2);
+    const remainingIds = res2.stabilizedDetections.map((d) => d.id);
+
+    // It should keep die-2 and die-3. die-1 should be missing.
+    expect(remainingIds).not.toContain('die-1');
+    expect(remainingIds).toContain('die-2');
+    expect(remainingIds).toContain('die-3');
+
+    // Verify that die-2 is still attached to the detection at x=150
+    const die2 = res2.stabilizedDetections.find((d) => d.id === 'die-2');
+    expect(die2?.x).toBe(150);
+  });
+
   it('respects manual overrides immediately', () => {
     const state = createInitialTrackerState();
 

--- a/src/lib/__tests__/dice-tracker.test.ts
+++ b/src/lib/__tests__/dice-tracker.test.ts
@@ -1,17 +1,18 @@
 import type { DiceDetection } from '../../domain/dice-detection';
+import type { DieValue } from '../../domain/die-value';
 import { createInitialTrackerState, updateDiceTracks } from '../dice-tracker';
 
 describe('dice-tracker', () => {
   const mockDetection = (
     x: number,
     y: number,
-    value: number = 1,
+    value: DieValue = 1,
   ): DiceDetection => ({
     x,
     y,
     width: 50,
     height: 50,
-    value: value as any,
+    value,
     confidence: 0.9,
   });
 
@@ -110,7 +111,7 @@ describe('dice-tracker', () => {
     const state = createInitialTrackerState();
 
     const detection = mockDetection(10, 10, 6);
-    detection.overrideValue = 1 as any;
+    detection.overrideValue = 1;
 
     const { stabilizedDetections } = updateDiceTracks(state, [detection]);
 

--- a/src/lib/app-info.ts
+++ b/src/lib/app-info.ts
@@ -1,0 +1,15 @@
+interface AppConfig {
+  expo: { version: string };
+}
+
+const { expo } = require('../../app.json') as AppConfig;
+
+/** Semantic version string from app.json (e.g. "1.0.1-dev"). */
+export const APP_VERSION: string = expo.version;
+
+/**
+ * True for any pre-release build — i.e. the version string contains a
+ * pre-release segment such as `-dev`.  Intended to gate developer overlays
+ * that should appear in non-final production builds as well as local dev.
+ */
+export const IS_PRE_RELEASE: boolean = APP_VERSION.includes('-');

--- a/src/lib/dice-processor.ts
+++ b/src/lib/dice-processor.ts
@@ -92,23 +92,22 @@ export function processDiceFrame({
     }
   }
 
+  const anchorStride = isTransposed ? 1 : numFeatures;
+  const featureStride = isTransposed ? numAnchors : 1;
+
   const detectionsArr: DiceDetection[] = [];
 
+  const classOffset = 4;
+  const numClasses = 6;
+
   for (let i = 0; i < numAnchors; i++) {
+    const anchorOff = i * anchorStride;
     let maxProb = 0;
     let classIdx = -1;
 
-    // For an 11-feature YOLOv8 model, usually [x, y, w, h] are indices 0-3.
-    // The next 6 are the classes (indices 4-9).
-    // The 11th feature is likely an empty padding class to align memory or an objectness score we ignore.
-    const classOffset = 4;
-    const numClasses = 6;
-
+    // Check dice classes
     for (let c = 0; c < numClasses; c++) {
-      const prob = isTransposed
-        ? outputTensor[(classOffset + c) * numAnchors + i]
-        : outputTensor[i * numFeatures + (classOffset + c)];
-
+      const prob = outputTensor[anchorOff + (classOffset + c) * featureStride];
       if (prob > maxProb) {
         maxProb = prob;
         classIdx = c;
@@ -116,28 +115,15 @@ export function processDiceFrame({
     }
 
     if (maxProb > confidenceThreshold) {
-      // Normalized coordinates
-      const cx = isTransposed
-        ? outputTensor[0 * numAnchors + i]
-        : outputTensor[i * numFeatures + 0];
-      const cy = isTransposed
-        ? outputTensor[1 * numAnchors + i]
-        : outputTensor[i * numFeatures + 1];
-      const w = isTransposed
-        ? outputTensor[2 * numAnchors + i]
-        : outputTensor[i * numFeatures + 2];
-      const h = isTransposed
-        ? outputTensor[3 * numAnchors + i]
-        : outputTensor[i * numFeatures + 3];
-
-      // Assuming normalized outputs (0.0 - 1.0)
-      // Since we cropped the camera feed into a perfect 1:1 square before passing it
-      // to the model, `cx`, `cy`, `w`, and `h` are percentages of that cropped square!
+      const cx = outputTensor[anchorOff + 0 * featureStride];
+      const cy = outputTensor[anchorOff + 1 * featureStride];
+      const w = outputTensor[anchorOff + 2 * featureStride];
+      const h = outputTensor[anchorOff + 3 * featureStride];
 
       const realW = w * cropSize;
       const realH = h * cropSize;
-      const realCx = cx * cropSize + offsetX; // Apply horizontal offset if the Camera component overflows the screen width
-      const realCy = cy * cropSize + cropY; // Push the Y down because the crop was centered vertically
+      const realCx = cx * cropSize + offsetX;
+      const realCy = cy * cropSize + cropY;
 
       detectionsArr.push({
         x: realCx - realW / 2,
@@ -156,9 +142,16 @@ export function processDiceFrame({
 
   for (const det of detectionsArr) {
     let isDuplicate = false;
+    const detCx = det.x + det.width / 2;
+    const detCy = det.y + det.height / 2;
+
     for (const finalDet of finalDetections) {
-      const dx = Math.abs(det.x - finalDet.x);
-      const dy = Math.abs(det.y - finalDet.y);
+      const finalDetCx = finalDet.x + finalDet.width / 2;
+      const finalDetCy = finalDet.y + finalDet.height / 2;
+
+      const dx = Math.abs(detCx - finalDetCx);
+      const dy = Math.abs(detCy - finalDetCy);
+
       if (dx < 30 && dy < 30) {
         isDuplicate = true;
         break;

--- a/src/lib/dice-tracker.ts
+++ b/src/lib/dice-tracker.ts
@@ -28,8 +28,13 @@ export function createInitialTrackerState(): TrackerState {
 
 function getMostFrequentValue(history: DiceDetection[]): DieValue {
   'worklet';
-  const counts = { 1: 0, 2: 0, 3: 0, 4: 0, 5: 0, 6: 0 };
+  if (history.length === 0) {
+    throw new Error('getMostFrequentValue called with empty history');
+  }
+
+  const counts: Record<number, number> = { 1: 0, 2: 0, 3: 0, 4: 0, 5: 0, 6: 0 };
   let maxCount = 0;
+  // Initialize with the most recent actual value as a fallback
   let mostFrequentValue = history[history.length - 1].value;
 
   for (const det of history) {
@@ -42,7 +47,6 @@ function getMostFrequentValue(history: DiceDetection[]): DieValue {
 
   return mostFrequentValue;
 }
-
 export function updateDiceTracks(
   state: TrackerState,
   currentDetections: DiceDetection[],
@@ -207,21 +211,9 @@ export function updateDiceTracks(
     if (!matchedTracks.has(tIdx)) {
       const track = state.tracks[tIdx];
       if (track.missingFrames < MAX_MISSING_FRAMES) {
-        const lastSeen = track.history[track.history.length - 1];
-        const shiftedLastSeen: DiceDetection = {
-          ...lastSeen,
-          x: lastSeen.x + bestTx,
-          y: lastSeen.y + bestTy,
-        };
-
-        const newHistory = [...track.history, shiftedLastSeen];
-        if (newHistory.length > HISTORY_SIZE) {
-          newHistory.shift();
-        }
-
         newTracks.push({
           id: track.id,
-          history: newHistory,
+          history: track.history,
           missingFrames: track.missingFrames + 1,
         });
       }

--- a/src/lib/dice-tracker.ts
+++ b/src/lib/dice-tracker.ts
@@ -140,53 +140,72 @@ export function updateDiceTracks(
       }
     }
   }
-  // --- Step 1: Match Tracks using Predicted Positions ---
-  for (const track of state.tracks) {
-    let bestMatchIdx = -1;
-    let minDistance = TRACKING_DISTANCE_THRESHOLD;
+  // --- Step 1: Match Tracks using Predicted Positions (Global Closest Pair) ---
+  // To prevent "ID stealing" (where track 1 steals the detection meant for track 2
+  // just because track 1 was evaluated first), we calculate ALL distances first,
+  // then match the absolute closest pairs globally.
 
+  const distances: { trackIdx: number; detIdx: number; dist: number }[] = [];
+
+  for (let tIdx = 0; tIdx < state.tracks.length; tIdx++) {
+    const track = state.tracks[tIdx];
     const lastSeen = track.history[track.history.length - 1];
-    // Apply the predicted camera movement to the old position
     const predictedCx = lastSeen.x + lastSeen.width / 2 + bestTx;
     const predictedCy = lastSeen.y + lastSeen.height / 2 + bestTy;
 
-    for (let i = 0; i < unmatchedDetections.length; i++) {
-      const det = unmatchedDetections[i];
+    for (let dIdx = 0; dIdx < unmatchedDetections.length; dIdx++) {
+      const det = unmatchedDetections[dIdx];
       const detCx = det.x + det.width / 2;
       const detCy = det.y + det.height / 2;
-
       const dist = Math.sqrt(
         Math.pow(detCx - predictedCx, 2) + Math.pow(detCy - predictedCy, 2),
       );
 
-      if (dist < minDistance) {
-        minDistance = dist;
-        bestMatchIdx = i;
+      if (dist < TRACKING_DISTANCE_THRESHOLD) {
+        distances.push({ trackIdx: tIdx, detIdx: dIdx, dist });
       }
     }
+  }
 
-    if (bestMatchIdx !== -1) {
-      // We found a match! Update the track.
-      const matchedDetection = unmatchedDetections[bestMatchIdx];
-      matchedDetection.id = track.id; // Assign the persistent ID
+  // Sort all possible matches by distance (closest first)
+  distances.sort((a, b) => a.dist - b.dist);
 
-      const newHistory = [...track.history, matchedDetection];
-      if (newHistory.length > HISTORY_SIZE) {
-        newHistory.shift(); // Keep only the last N items
-      }
+  const matchedTracks = new Set<number>();
+  const matchedDetections = new Set<number>();
 
-      newTracks.push({
-        id: track.id,
-        history: newHistory,
-        missingFrames: 0,
-      });
+  for (const match of distances) {
+    if (
+      matchedTracks.has(match.trackIdx) ||
+      matchedDetections.has(match.detIdx)
+    ) {
+      continue; // One of these has already been claimed by a closer match
+    }
 
-      // Remove from unmatched so it isn't matched again
-      unmatchedDetections.splice(bestMatchIdx, 1);
-    } else {
-      // No match found. The die is missing in this frame.
+    matchedTracks.add(match.trackIdx);
+    matchedDetections.add(match.detIdx);
+
+    const track = state.tracks[match.trackIdx];
+    const matchedDetection = unmatchedDetections[match.detIdx];
+    matchedDetection.id = track.id;
+
+    const newHistory = [...track.history, matchedDetection];
+    if (newHistory.length > HISTORY_SIZE) {
+      newHistory.shift();
+    }
+
+    newTracks.push({
+      id: track.id,
+      history: newHistory,
+      missingFrames: 0,
+    });
+  }
+
+  // Handle tracks that didn't find a match (Missing Frames)
+  for (let tIdx = 0; tIdx < state.tracks.length; tIdx++) {
+    if (!matchedTracks.has(tIdx)) {
+      const track = state.tracks[tIdx];
       if (track.missingFrames < MAX_MISSING_FRAMES) {
-        // Shift the "revived" detection by the camera movement so it follows the screen!
+        const lastSeen = track.history[track.history.length - 1];
         const shiftedLastSeen: DiceDetection = {
           ...lastSeen,
           x: lastSeen.x + bestTx,
@@ -205,6 +224,15 @@ export function updateDiceTracks(
         });
       }
     }
+  }
+
+  // Remove the claimed detections from unmatchedDetections so they aren't created as new tracks.
+  // We iterate backwards to avoid messing up indices.
+  const sortedMatchedDetections = Array.from(matchedDetections).sort(
+    (a, b) => b - a,
+  );
+  for (const detIdx of sortedMatchedDetections) {
+    unmatchedDetections.splice(detIdx, 1);
   }
 
   // --- Step 2: Create new tracks for remaining unmatched detections ---
@@ -232,6 +260,7 @@ export function updateDiceTracks(
       return {
         ...latest,
         value: latest.overrideValue,
+        historyLength: t.history.length,
       };
     }
 
@@ -240,6 +269,7 @@ export function updateDiceTracks(
     return {
       ...latest,
       value: stabilizedValue,
+      historyLength: t.history.length,
     };
   });
 

--- a/src/lib/dice-tracker.ts
+++ b/src/lib/dice-tracker.ts
@@ -1,0 +1,234 @@
+import type { DiceDetection } from '../domain/dice-detection';
+import type { DieValue } from '../domain/die-value';
+
+// Maximum distance a die center can move between frames to be considered the same die.
+const TRACKING_DISTANCE_THRESHOLD = 80;
+// How many frames a die can be "missing" before we stop tracking it completely.
+const MAX_MISSING_FRAMES = 5;
+// How many previous detections to keep for voting and smoothing.
+const HISTORY_SIZE = 10;
+
+export interface TrackedDie {
+  id: string;
+  history: DiceDetection[];
+  missingFrames: number;
+}
+
+export interface TrackerState {
+  nextId: number;
+  tracks: TrackedDie[];
+}
+
+export function createInitialTrackerState(): TrackerState {
+  return {
+    nextId: 1,
+    tracks: [],
+  };
+}
+
+function getMostFrequentValue(history: DiceDetection[]): DieValue {
+  'worklet';
+  const counts = { 1: 0, 2: 0, 3: 0, 4: 0, 5: 0, 6: 0 };
+  let maxCount = 0;
+  let mostFrequentValue = history[history.length - 1].value;
+
+  for (const det of history) {
+    counts[det.value]++;
+    if (counts[det.value] > maxCount) {
+      maxCount = counts[det.value];
+      mostFrequentValue = det.value;
+    }
+  }
+
+  return mostFrequentValue;
+}
+
+export function updateDiceTracks(
+  state: TrackerState,
+  currentDetections: DiceDetection[],
+): { state: TrackerState; stabilizedDetections: DiceDetection[] } {
+  'worklet';
+  const newTracks: TrackedDie[] = [];
+  const unmatchedDetections = [...currentDetections];
+
+  // --- Step 0: Predict Camera Movement (Constellation Matching) ---
+  let bestTx = 0;
+  let bestTy = 0;
+
+  if (state.tracks.length > 0 && currentDetections.length > 0) {
+    let maxScore = -1;
+    // Always evaluate the "no movement" hypothesis first.
+    // We give it a slight artificial boost so that if it ties with a random shift,
+    // we prefer to assume the camera didn't move.
+    const hypotheses = [{ tx: 0, ty: 0, isZero: true }];
+
+    // Generate translation hypotheses from all pairs of old track -> new detection
+    for (const track of state.tracks) {
+      const tLast = track.history[track.history.length - 1];
+      const tCx = tLast.x + tLast.width / 2;
+      const tCy = tLast.y + tLast.height / 2;
+      for (const det of currentDetections) {
+        hypotheses.push({
+          tx: det.x + det.width / 2 - tCx,
+          ty: det.y + det.height / 2 - tCy,
+          isZero: false,
+        });
+      }
+    }
+
+    // Score each hypothesis by how many dice align with it
+    for (const hyp of hypotheses) {
+      let score = hyp.isZero ? 0.5 : 0; // Bias towards staying still
+      const claimedDetections = new Set<number>();
+
+      for (const track of state.tracks) {
+        const tLast = track.history[track.history.length - 1];
+        const predictedCx = tLast.x + tLast.width / 2 + hyp.tx;
+        const predictedCy = tLast.y + tLast.height / 2 + hyp.ty;
+
+        let matched = false;
+        for (let i = 0; i < currentDetections.length; i++) {
+          if (claimedDetections.has(i)) continue; // Don't let two old tracks claim the same new detection
+
+          const det = currentDetections[i];
+          const detCx = det.x + det.width / 2;
+          const detCy = det.y + det.height / 2;
+          const dist = Math.sqrt(
+            Math.pow(detCx - predictedCx, 2) + Math.pow(detCy - predictedCy, 2),
+          );
+
+          if (dist < TRACKING_DISTANCE_THRESHOLD) {
+            score += 1;
+            // Small tie-breaker to favor hypotheses that preserve face values
+            if (det.value === tLast.value) {
+              score += 0.1;
+            }
+            claimedDetections.add(i);
+            matched = true;
+            break; // Move to next track
+          }
+        }
+
+        // If a hypothesis causes an old track to completely miss any new detections,
+        // penalize it slightly to prefer hypotheses that match more of the total constellation.
+        if (!matched) {
+          score -= 0.2;
+        }
+      }
+
+      if (score > maxScore) {
+        maxScore = score;
+        bestTx = hyp.tx;
+        bestTy = hyp.ty;
+      }
+    }
+  }
+
+  // --- Step 1: Match Tracks using Predicted Positions ---
+  for (const track of state.tracks) {
+    let bestMatchIdx = -1;
+    let minDistance = TRACKING_DISTANCE_THRESHOLD;
+
+    const lastSeen = track.history[track.history.length - 1];
+    // Apply the predicted camera movement to the old position
+    const predictedCx = lastSeen.x + lastSeen.width / 2 + bestTx;
+    const predictedCy = lastSeen.y + lastSeen.height / 2 + bestTy;
+
+    for (let i = 0; i < unmatchedDetections.length; i++) {
+      const det = unmatchedDetections[i];
+      const detCx = det.x + det.width / 2;
+      const detCy = det.y + det.height / 2;
+
+      const dist = Math.sqrt(
+        Math.pow(detCx - predictedCx, 2) + Math.pow(detCy - predictedCy, 2),
+      );
+
+      if (dist < minDistance) {
+        minDistance = dist;
+        bestMatchIdx = i;
+      }
+    }
+
+    if (bestMatchIdx !== -1) {
+      // We found a match! Update the track.
+      const matchedDetection = unmatchedDetections[bestMatchIdx];
+      matchedDetection.id = track.id; // Assign the persistent ID
+
+      const newHistory = [...track.history, matchedDetection];
+      if (newHistory.length > HISTORY_SIZE) {
+        newHistory.shift(); // Keep only the last N items
+      }
+
+      newTracks.push({
+        id: track.id,
+        history: newHistory,
+        missingFrames: 0,
+      });
+
+      // Remove from unmatched so it isn't matched again
+      unmatchedDetections.splice(bestMatchIdx, 1);
+    } else {
+      // No match found. The die is missing in this frame.
+      if (track.missingFrames < MAX_MISSING_FRAMES) {
+        // Shift the "revived" detection by the camera movement so it follows the screen!
+        const shiftedLastSeen: DiceDetection = {
+          ...lastSeen,
+          x: lastSeen.x + bestTx,
+          y: lastSeen.y + bestTy,
+        };
+
+        const newHistory = [...track.history, shiftedLastSeen];
+        if (newHistory.length > HISTORY_SIZE) {
+          newHistory.shift();
+        }
+
+        newTracks.push({
+          id: track.id,
+          history: newHistory,
+          missingFrames: track.missingFrames + 1,
+        });
+      }
+    }
+  }
+
+  // --- Step 2: Create new tracks for remaining unmatched detections ---
+  let newNextId = state.nextId;
+  for (const det of unmatchedDetections) {
+    const id = `die-${newNextId++}`;
+    det.id = id;
+    newTracks.push({
+      id,
+      history: [det],
+      missingFrames: 0,
+    });
+  }
+
+  // --- Step 3: Generate the "stabilized" current state ---
+  // We ONLY return tracks that were physically matched or newly created in THIS frame.
+  // We do NOT return "missing" tracks (missingFrames > 0), so we don't draw ghost overlays.
+  // Their history is still kept in the `state` so they can be re-linked if they reappear.
+  const activeTracks = newTracks.filter((t) => t.missingFrames === 0);
+
+  const stabilizedDetections = activeTracks.map((t) => {
+    const latest = t.history[t.history.length - 1];
+
+    if (latest.overrideValue) {
+      return {
+        ...latest,
+        value: latest.overrideValue,
+      };
+    }
+
+    const stabilizedValue = getMostFrequentValue(t.history);
+
+    return {
+      ...latest,
+      value: stabilizedValue,
+    };
+  });
+
+  return {
+    state: { nextId: newNextId, tracks: newTracks },
+    stabilizedDetections,
+  };
+}

--- a/src/lib/dice-tracker.ts
+++ b/src/lib/dice-tracker.ts
@@ -88,12 +88,9 @@ export function updateDiceTracks(
     }
 
     // Score each hypothesis by how many dice align with it
-    const perfectScore = activeTracks.length;
-
     for (const hyp of hypotheses) {
       let score = hyp.isZero ? 0.5 : 0; // Bias towards staying still
       const claimedDetections = new Set<number>();
-      let rawMatches = 0;
 
       for (const track of activeTracks) {
         const tLast = track.history[track.history.length - 1];
@@ -113,7 +110,6 @@ export function updateDiceTracks(
 
           if (dist < TRACKING_DISTANCE_THRESHOLD) {
             score += 1;
-            rawMatches += 1;
             // Small tie-breaker to favor hypotheses that preserve face values
             if (det.value === tLast.value) {
               score += 0.1;
@@ -135,12 +131,6 @@ export function updateDiceTracks(
         maxScore = score;
         bestTx = hyp.tx;
         bestTy = hyp.ty;
-      }
-
-      // Early short-circuit: If we perfectly matched all active tracks, we don't need to check worse hypotheses.
-      // We subtract the 0.5 zero-bias from maxScore to see if we hit the raw perfect score.
-      if (Math.floor(maxScore) >= perfectScore && rawMatches === perfectScore) {
-        break;
       }
     }
   }

--- a/src/lib/dice-tracker.ts
+++ b/src/lib/dice-tracker.ts
@@ -55,19 +55,26 @@ export function updateDiceTracks(
   let bestTx = 0;
   let bestTy = 0;
 
-  if (state.tracks.length > 0 && currentDetections.length > 0) {
+  // Filter to active tracks to avoid generating hypotheses from ghosts
+  const activeTracks = state.tracks.filter((t) => t.missingFrames === 0);
+
+  if (activeTracks.length > 0 && currentDetections.length > 0) {
     let maxScore = -1;
     // Always evaluate the "no movement" hypothesis first.
-    // We give it a slight artificial boost so that if it ties with a random shift,
-    // we prefer to assume the camera didn't move.
     const hypotheses = [{ tx: 0, ty: 0, isZero: true }];
 
-    // Generate translation hypotheses from all pairs of old track -> new detection
-    for (const track of state.tracks) {
+    // Optimization: Only use the top 10 most confident new detections to generate hypotheses
+    // to prevent O(N^4) explosion if there is heavy noise/clutter.
+    const reliableDetections = [...currentDetections]
+      .sort((a, b) => b.confidence - a.confidence)
+      .slice(0, 10);
+
+    // Generate translation hypotheses from all pairs of active track -> reliable detection
+    for (const track of activeTracks) {
       const tLast = track.history[track.history.length - 1];
       const tCx = tLast.x + tLast.width / 2;
       const tCy = tLast.y + tLast.height / 2;
-      for (const det of currentDetections) {
+      for (const det of reliableDetections) {
         hypotheses.push({
           tx: det.x + det.width / 2 - tCx,
           ty: det.y + det.height / 2 - tCy,
@@ -77,11 +84,14 @@ export function updateDiceTracks(
     }
 
     // Score each hypothesis by how many dice align with it
+    const perfectScore = activeTracks.length;
+
     for (const hyp of hypotheses) {
       let score = hyp.isZero ? 0.5 : 0; // Bias towards staying still
       const claimedDetections = new Set<number>();
+      let rawMatches = 0;
 
-      for (const track of state.tracks) {
+      for (const track of activeTracks) {
         const tLast = track.history[track.history.length - 1];
         const predictedCx = tLast.x + tLast.width / 2 + hyp.tx;
         const predictedCy = tLast.y + tLast.height / 2 + hyp.ty;
@@ -99,6 +109,7 @@ export function updateDiceTracks(
 
           if (dist < TRACKING_DISTANCE_THRESHOLD) {
             score += 1;
+            rawMatches += 1;
             // Small tie-breaker to favor hypotheses that preserve face values
             if (det.value === tLast.value) {
               score += 0.1;
@@ -109,7 +120,7 @@ export function updateDiceTracks(
           }
         }
 
-        // If a hypothesis causes an old track to completely miss any new detections,
+        // If a hypothesis causes an active track to completely miss any new detections,
         // penalize it slightly to prefer hypotheses that match more of the total constellation.
         if (!matched) {
           score -= 0.2;
@@ -121,9 +132,14 @@ export function updateDiceTracks(
         bestTx = hyp.tx;
         bestTy = hyp.ty;
       }
+
+      // Early short-circuit: If we perfectly matched all active tracks, we don't need to check worse hypotheses.
+      // We subtract the 0.5 zero-bias from maxScore to see if we hit the raw perfect score.
+      if (Math.floor(maxScore) >= perfectScore && rawMatches === perfectScore) {
+        break;
+      }
     }
   }
-
   // --- Step 1: Match Tracks using Predicted Positions ---
   for (const track of state.tracks) {
     let bestMatchIdx = -1;
@@ -195,10 +211,10 @@ export function updateDiceTracks(
   let newNextId = state.nextId;
   for (const det of unmatchedDetections) {
     const id = `die-${newNextId++}`;
-    det.id = id;
+    const newDetection = { ...det, id };
     newTracks.push({
       id,
-      history: [det],
+      history: [newDetection],
       missingFrames: 0,
     });
   }
@@ -207,9 +223,9 @@ export function updateDiceTracks(
   // We ONLY return tracks that were physically matched or newly created in THIS frame.
   // We do NOT return "missing" tracks (missingFrames > 0), so we don't draw ghost overlays.
   // Their history is still kept in the `state` so they can be re-linked if they reappear.
-  const activeTracks = newTracks.filter((t) => t.missingFrames === 0);
+  const visibleTracks = newTracks.filter((t) => t.missingFrames === 0);
 
-  const stabilizedDetections = activeTracks.map((t) => {
+  const stabilizedDetections = visibleTracks.map((t) => {
     const latest = t.history[t.history.length - 1];
 
     if (latest.overrideValue) {

--- a/src/lib/dice-tracker.ts
+++ b/src/lib/dice-tracker.ts
@@ -185,8 +185,10 @@ export function updateDiceTracks(
     matchedDetections.add(match.detIdx);
 
     const track = state.tracks[match.trackIdx];
-    const matchedDetection = unmatchedDetections[match.detIdx];
-    matchedDetection.id = track.id;
+    const matchedDetection = {
+      ...unmatchedDetections[match.detIdx],
+      id: track.id,
+    };
 
     const newHistory = [...track.history, matchedDetection];
     if (newHistory.length > HISTORY_SIZE) {


### PR DESCRIPTION
Add dice-tracker
- **Tracking:** has two ways of keeping track of individual dice through the frames:
  - It checks whether the camera might have moved, and predict the new positions
  - Euclidean Distance: For every die, it checks with each new die detection if it's closest to any die's past detection or it's predicted new position
- **History:** It keeps the history of a die for 10 frames
  - It improves the value evaluation by determine the most frequent value of a die
  - It offers a manual override (will be picked up in another feature)
-  **AR-Overlay:** For Dev-builds the tracking data is shown in the AR-Overlay to observe its stability